### PR TITLE
feat: when no command is specified show the help message

### DIFF
--- a/lib/bin.ts
+++ b/lib/bin.ts
@@ -23,4 +23,5 @@ yargs(process.argv.slice(2))
   .command(...statusCommand)
   .command(...clearCommand)
   .completion("completion", "Generate completion script.")
+  .demandCommand(1, "")
   .help().argv;


### PR DESCRIPTION
Currently if you only run `linear` there is no output so it's not obvious if anything was done. This PR would replace the output with the `--help` output.

Before:
```bash
linear ↵


```

After:
```bash
linear ↵
linear <command>

Commands:
  linear login       Authenticate using personal API key. Generate a new API key
                     at https://linear.app/contra/settings/api

  linear logout      Remove API key from keychain.

  linear new         Create a new issue.

  linear checkout    Create and checkout a new branch for a specific issue.

  linear status      Update the status of an issue. Uses the current git branch
                     name to identify the issue to update when possible.

  linear clear       Clear the cache. This should be done when there are changes
                     to your Linear settings. Cache directory:
                     /Users/mike/Library/Caches/linear-cli

  linear completion  Generate completion script.

Options:
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]

```